### PR TITLE
T6613: improve line buffer for config file from 256 -> 2048 byte

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libnss-tacplus (1.0.4-cl5.1.0u11.1) UNRELEASED; urgency=medium
+
+  * Improve line buffer for config file from 256 -> 2048 byte
+
+ -- Christian Breunig <christian@breunig.cc>  Sun, 15 Dec 2024 10:40:40 +0100
+
 libnss-tacplus (1.0.4-cl5.1.0u11) RELEASED; urgency=medium
 
   * new build for 5.1.0 from original hash

--- a/nss_tacplus.c
+++ b/nss_tacplus.c
@@ -144,7 +144,7 @@ static int str_to_ipv4(const char *srcaddr, struct addrinfo *p_addr_info)
 static int nss_tacplus_config(int *errnop, const char *cfile, int top)
 {
     FILE *conf;
-    char lbuf[256];
+    char lbuf[2048];
     static struct stat lastconf[MAX_INCL];
     static char *cfilelist[MAX_INCL];
     struct stat st, *lst;


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Support extensive length of exclude_users to avoid truncation in VyOS.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6613

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4238

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
