### PR TITLE
T8083: Fix NSS TACACS group buffer truncation

### DIFF
--- a/nss_tacplus.c
+++ b/nss_tacplus.c
@@ -1042,7 +1042,8 @@ fixup_gr_mem(const char *grnam, const char **gr_in, char *buf,
         *err = ERANGE;
         *lenp = 0;
         if (debug)
-            syslog(LOG_DEBUG, "%s: group %s needs %llu bytes, only %llu available. Flagging for reallocation",
+            syslog(LOG_DEBUG, "%s: group %s needs %llu bytes, only %llu "
+                "available. Flagging for reallocation",
                 nssname, grnam, l, len);
         return NULL;
     }
@@ -1057,19 +1058,39 @@ fixup_gr_mem(const char *grnam, const char **gr_in, char *buf,
             char *saved, *tok;
             tok = strtok_r(mapnames, ",", &saved);
             while (tok) {
+                /* T8083:Fix to handle the scenario where no. of members in the
+                *  group increase between the execution of the two passes, i.e
+                *  lookup_all_mapped() returns different strings in first
+                *  and second pass */
+                if (midx >= nadded) {
+                    syslog(LOG_WARNING, "%s: group %s No of members fetched "
+                        "exceeded in second pass. First pass count was %d."
+                        "Flagging for reallocation!", nssname, grnam, nadded);
+                    free(mapnames);
+                    *err = ERANGE;
+                    return NULL;
+                }
                 gr_mem[midx] = mem;
                 if(copyuser(&mem, tok, &len, err)) {
                     free(mapnames);
                     mapnames = NULL;
                     goto done;
-		}
+                }
                 midx++;
                 tok = strtok_r(NULL, ",", &saved);
             }
-	    free(mapnames);
-	    mapnames = NULL;
+            free(mapnames);
+            mapnames = NULL;
         }
         else { /*  just copy what was returned to the buffer */
+            if (midx >= nadded) {
+                syslog(LOG_WARNING, "%s: group %s No of members fetched "
+                    "exceeded in second pass. First pass count was %d, midx=%d *in=%s."
+                    "Flagging for reallocation!", nssname, grnam, nadded, midx, *in);
+                    *err = ERANGE;
+                    return NULL;
+            }
+
             gr_mem[midx] = mem;
             if(copyuser(&mem, *in, &len, err))
                 goto done;
@@ -1081,8 +1102,9 @@ fixup_gr_mem(const char *grnam, const char **gr_in, char *buf,
     gr_mem[midx] = NULL;        /*  terminate the list */
 
     if (*err) {
-        syslog(LOG_WARNING, "%s: group %s members truncated due to short"
-               " buffer %lld characters", nssname, grnam, (long long)*lenp);
+        syslog(LOG_WARNING, "%s: group %s buffer len %lld. Unexpected change in "
+               "no. of group members b/w passes or some error. Flagging for "
+               "error/reallocation!", nssname, grnam, (long long)*lenp);
         *lenp = 0;
     } else {
         out = gr_mem;

--- a/nss_tacplus.c
+++ b/nss_tacplus.c
@@ -1026,6 +1026,8 @@ fixup_gr_mem(const char *grnam, const char **gr_in, char *buf,
                 total_chars += (long long)strlen(tok) + 1;
                 tok = strtok_r(NULL, ",", &saved);
             }
+            free(mapnames);
+            mapnames = NULL;
         }
         else {
             nadded++;
@@ -1056,11 +1058,16 @@ fixup_gr_mem(const char *grnam, const char **gr_in, char *buf,
             tok = strtok_r(mapnames, ",", &saved);
             while (tok) {
                 gr_mem[midx] = mem;
-                if(copyuser(&mem, tok, &len, err))
+                if(copyuser(&mem, tok, &len, err)) {
+                    free(mapnames);
+                    mapnames = NULL;
                     goto done;
+		}
                 midx++;
                 tok = strtok_r(NULL, ",", &saved);
             }
+	    free(mapnames);
+	    mapnames = NULL;
         }
         else { /*  just copy what was returned to the buffer */
             gr_mem[midx] = mem;

--- a/nss_tacplus.c
+++ b/nss_tacplus.c
@@ -1014,6 +1014,8 @@ fixup_gr_mem(const char *grnam, const char **gr_in, char *buf,
      * space in gr_mem, but it's not too expensive, no connects
      * to a tacacs server.
     */
+    /* First pass: count pointers AND total bytes required for strings */
+    long long total_chars = 0;
     for (in=gr_in; in && *in; in++) {
         char *mapnames = lookup_all_mapped(*in);
         if (mapnames) { /*  comma separated list was returned  */
@@ -1021,13 +1023,28 @@ fixup_gr_mem(const char *grnam, const char **gr_in, char *buf,
             tok = strtok_r(mapnames, ",", &saved);
             while (tok) {
                 nadded++;
+                total_chars += (long long)strlen(tok) + 1;
                 tok = strtok_r(NULL, ",", &saved);
             }
         }
-        else
+        else {
             nadded++;
+            total_chars += (long long)strlen(*in) + 1;
+        }
     }
-    l = sizeof *gr_mem * (nadded+1);
+
+    /* required = pointer array + all strings (alignment already applied) */
+    l = (long long)sizeof *gr_mem * (nadded + 1) + total_chars;
+    if (l > len) {
+        /* fail fast so caller/GLIBC can TRYAGAIN without partial copies */
+        *err = ERANGE;
+        *lenp = 0;
+        if (debug)
+            syslog(LOG_DEBUG, "%s: group %s needs %llu bytes, only %llu available. Flagging for reallocation",
+                nssname, grnam, l, len);
+        return NULL;
+    }
+    l = (long long)sizeof *gr_mem * (nadded+1);
     len -= l;
     mem += l;
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
- Prevent partial copying of group members into the NSS buffer, by an early detection of buffer shortage before actually copying
- Address memory leaks in fixup_gr_mem().

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
https://vyos.dev/T8083
https://internal.jira.vyos.com/browse/VD-2423

<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->
The warning is being emitted while processing the member strings of the groups which have large number of members like 19–21+ . 
For these cases, the NSS buffer length is falling short to hold them all. 
The code execution starts copying member strings and later discover the buffer had run out of space, logged a WARNING, and returned error ERANGE to indicate retrial request for reallocation with larger buffer size. 
ERANGE is translated by the NSS layer to NSS_STATUS_TRYAGAIN, which causes glibc to retry the lookup and pass a larger buffer; the retry typically succeeds and group processing completes. That is why operations still succeed despite the warnings.
But, all this leads to unnecessary partial copying, though there does not seem an error as such.
Partial copying can be prevented by an early detection of buffer shortage before actually copying. The retrial mechanism still remains the same.

Also, addressed few memory leaks in fixup_gr_mem().

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Launched a TACACS server and executed the commands specified in the Phabricator task on VyOS VM.
- The truncation error log is no longer seen. It will be logged in case of any error while copying.
- If debug logs are enabled, a log similar to the below logs would be observed just to indicate that a reallocation was requested:
```
Jun 26 15:01:29 usermod[3736]: nss_tacplus: group frrvty needs 355 bytes, only 208 available. Flagging for reallocation
Jun 26 15:01:29 usermod[3736]: nss_tacplus: group adm needs 343 bytes, only 211 available. Flagging for reallocation
Jun 26 15:01:29 usermod[3736]: nss_tacplus: group dip needs 343 bytes, only 211 available. Flagging for reallocation
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
