### PR TITLE
general: T8595: add CLAUDE.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,13 +7,14 @@ NSS plugin (`libnss_tacplus.so`) that resolves `getpwnam` lookups for TACACS+-au
 ## Tech stack
 
 - C, GNU autotools (`configure.ac`, `Makefile.am`, `aclocal.m4`).
-- Debian packaging in `debian/` (debhelper >= 9, autotools-dev, `libtac-dev`).
+- Debian packaging in `debian/` (debhelper >= 9, autotools-dev, `libtac-dev`, `libtacplus-map-dev`, `libaudit-dev`, `libpam-tacplus-dev`).
 - License: GPL-2.0 (per `COPYING`).
 
 ## Build / test / run
 
 ```sh
-./auto.sh                 # autoreconf + ./configure
+./auto.sh                 # autoreconf (generates ./configure)
+./configure
 make
 sudo make install         # installs libnss_tacplus.so + tacplus_nss.conf
 dpkg-buildpackage -us -uc # debian package build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# CLAUDE.md
+
+## Project purpose
+
+NSS plugin (`libnss_tacplus.so`) that resolves `getpwnam` lookups for TACACS+-authenticated users that have no local `/etc/passwd` entry. Maps remote TACACS+ users onto the local `tacacs0..15` stub accounts and pulls home/uid/gid via `libtacplus-map`. Used together with `libpam-tacplus` for full TACACS+ login flow on VyOS.
+
+## Tech stack
+
+- C, GNU autotools (`configure.ac`, `Makefile.am`, `aclocal.m4`).
+- Debian packaging in `debian/` (debhelper >= 9, autotools-dev, `libtac-dev`).
+- License: GPL-2.0 (per `COPYING`).
+
+## Build / test / run
+
+```sh
+./auto.sh                 # autoreconf + ./configure
+make
+sudo make install         # installs libnss_tacplus.so + tacplus_nss.conf
+dpkg-buildpackage -us -uc # debian package build
+```
+
+No in-tree test suite — exercised end-to-end on a VyOS image via `pam_tacplus` login.
+
+## Repository layout
+
+- `nss_tacplus.c`, `nss_tacplus.h` — NSS module entry points.
+- `tacplus_nss.conf`, `tacplus_nss.conf.5` — config file + man page.
+- `debian/` — Debian packaging.
+
+## Cross-repo context
+
+Pre-dep of the `vyos-1x` runtime auth stack. Built via `VyOS-Networks/vyos-build-packages` and shipped in the ISO from `vyos/vyos-build`. Calls into `libtacplus-map` (mapping helper) and the `libtac` library produced by `libpam-tacplus`. Companion repos: `libpam-tacplus`, `libtacplus-map`, `libnss-mapuser`, `libpam-radius-auth`.
+
+## Conventions
+
+- Default branch `master` (forked from `daveolson53/libnss-tacplus`).
+- Commit / PR title format: `component: T12345: description` (Phorge task ID at https://vyos.dev) — enforced if PR-message workflow is added later. No workflow files currently in `.github/workflows/`.
+- Treat as upstream-vendored: keep diffs against fork minimal; new functionality belongs in `libtacplus-map` or `libpam-tacplus`.
+
+## Mirror relationship
+
+Mirror twin: `VyOS-Networks/libnss-tacplus`. Canonical side is here. The mirror pipeline (`vyos/.github/.github/workflows/pr-mirror-repo-sync.yml`) is **not** wired up for this repo today (no workflows in `.github/workflows/`).
+
+## Notes for future contributors
+
+- README is upstream's `libnss_tacplus v1.0.1` text (June 2016) — do not assume it documents VyOS-specific patches.
+- Outbound webhook to `hooks.zapier.com` is configured at the repo level (audit baseline 2026-04-18).
+- LTS-only changes go to `sagitta`/`circinus`/`equuleus` branches if/when created; today only `master` exists.
+
+---
+
+This file is mirrored on Confluence: [`vyos/libnss-tacplus`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818544732). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,14 +7,13 @@ NSS plugin (`libnss_tacplus.so`) that resolves `getpwnam` lookups for TACACS+-au
 ## Tech stack
 
 - C, GNU autotools (`configure.ac`, `Makefile.am`, `aclocal.m4`).
-- Debian packaging in `debian/` (debhelper >= 9, autotools-dev, `libtac-dev`, `libtacplus-map-dev`, `libaudit-dev`, `libpam-tacplus-dev`).
+- Debian packaging in `debian/` (debhelper >= 9, autotools-dev, `libtac-dev`).
 - License: GPL-2.0 (per `COPYING`).
 
 ## Build / test / run
 
 ```sh
-./auto.sh                 # autoreconf (generates ./configure)
-./configure
+./auto.sh                 # autoreconf + ./configure
 make
 sudo make install         # installs libnss_tacplus.so + tacplus_nss.conf
 dpkg-buildpackage -us -uc # debian package build
@@ -47,7 +46,3 @@ Mirror twin: `VyOS-Networks/libnss-tacplus`. Canonical side is here. The mirror 
 - README is upstream's `libnss_tacplus v1.0.1` text (June 2016) — do not assume it documents VyOS-specific patches.
 - Outbound webhook to `hooks.zapier.com` is configured at the repo level (audit baseline 2026-04-18).
 - LTS-only changes go to `sagitta`/`circinus`/`equuleus` branches if/when created; today only `master` exists.
-
----
-
-This file is mirrored on Confluence: [`vyos/libnss-tacplus`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818544732). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.


### PR DESCRIPTION
## Summary

Adds a single source of truth for repo-level agent instructions, plus three symlinks so different agentic tools all read the same content from one canonical file.

**Files added:**

| Path | Type | Consumed by |
|---|---|---|
| `CLAUDE.md` | real file | Claude Code, Anthropic agents |
| `AGENTS.md` | symlink → `CLAUDE.md` | tools that follow the AGENTS.md convention (e.g. OpenAI Codex) |
| `.cursorrules` | symlink → `CLAUDE.md` | Cursor |
| `.github/copilot-instructions.md` | symlink → `../CLAUDE.md` | GitHub Copilot ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide)) |

**Rationale**

- One source of truth — guidance lives in `CLAUDE.md`, the symlinks are zero-content. No drift between four files.
- Each agentic tool reads its canonical filename and gets the same content.
- Mac/Linux dev environments handle symlinks natively. Windows checkouts may render them as text files containing the target path; the canonical `CLAUDE.md` is unaffected and still rendered/served correctly by GitHub.

**Out of scope**

Path-specific Copilot instructions (`.github/instructions/*.instructions.md`) need YAML frontmatter (`applyTo:`) and target specific globs, so they cannot be symlinks. Not added here; they can be authored as separate small files per-repo if/when narrow path-scoped guidance is needed.

Tracked under [T8595](https://vyos.dev/T8595).

## Test plan

- [ ] `CLAUDE.md` renders on GitHub.
- [ ] `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md` resolve to CLAUDE.md content (`readlink` returns the right target).
- [ ] CI passes.

🤖 Generated by [robots](https://vyos.io)
