### PR TITLE
T8943: migrate pr-mirror wrapper to canonical stub + add extends:mergify config

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://docs.mergify.com/mergify-configuration-schema.json
+extends: mergify
+merge_protections_settings:
+  reporting_method: check-runs

--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -1,35 +1,27 @@
+# .github/workflows/pr-mirror-repo-sync.yml
+# DO NOT EDIT — managed by mirror-pipeline rollout.
+# To opt out: set vars.MIRROR_ENABLED=false in this repo's Actions variables.
 name: PR Mirror and Repo Sync
 
 on:
   pull_request_target:
     types: [closed]
-    branches: [rolling]
+    branches: [rolling, production]
   workflow_dispatch:
     inputs:
       sync_branch:
-        description: 'Branch to mirror'
         required: true
-        default: 'rolling'
-        type: choice
-        options:
-          - rolling
+        type: string
 
 permissions:
-  pull-requests: write
-  contents: write
-  issues: write
+  contents: read
 
 jobs:
-  call-pr-mirror-repo-sync:
+  call:
     if: |
-      github.repository_owner == 'vyos' &&
-      (
-        github.event_name == 'workflow_dispatch' ||
-        (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true)
-      )
+      github.repository_owner == 'vyos'
+      && (github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch')
     uses: vyos/.github/.github/workflows/pr-mirror-repo-sync.yml@production
     with:
-      sync_branch: ${{ github.event.inputs.sync_branch || 'rolling' }}
-    secrets:
-      PAT: ${{ secrets.PAT }}
-      REMOTE_OWNER: ${{ secrets.REMOTE_OWNER }}
+      sync_branch: ${{ inputs.sync_branch || github.event.pull_request.base.ref }}
+    secrets: inherit


### PR DESCRIPTION
Mirror Pipeline Rollout 2 Task 6 — the last consumers.yaml repo on the pre-1b custom wrapper.

Two changes so the diverged mirror reconciles **losslessly**:
1. `.github/workflows/pr-mirror-repo-sync.yml` → canonical uniform stub (was the pre-1b custom form: choice-typed dispatch, `contents/pull-requests/issues: write`, divergent job name).
2. Add `.github/mergify.yml` (`extends: mergify`) — the source was missing it while the mirror target already carried it (added via direct VN-side PRs). Bringing the source to the full desired state means the mirror's reconcile of the diverged target preserves the Mergify config instead of dropping it.

Divergence: source `98348eb` / target `db04b57` (genuinely diverged; only net tree diff was the missing mergify.yml). Target snapshotted at `backup/pre-libnss-tacplus-reconcile-20260531` before reconcile. Brings consumers to 18/19 canonical (mirror-canary excluded).

Tracking: T8943.

🤖 Generated by [robots](https://vyos.io)